### PR TITLE
Fix missing author, homepage and other fields in pip show

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -11,9 +11,12 @@ version = "2.0.0"
 authors = [
     { name = "allanhanan", email = "allan.hanan04@gmail.com" }
 ]
+author = "allanhanan"
+author_email = "allan.hanan04@gmail.com"
 description = "DirectShow UVC Camera Control Library"
 readme = "PYPI_README.md"
 license = { file = "../../LICENSE" }
+homepage = "https://github.com/allanhanan/duvc-ctl"
 requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
Add legacy setup.py style fields